### PR TITLE
Dirty lockfile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.lockb binary diff=lockb

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "module": "index.ts",
   "type": "module",
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"


### PR DESCRIPTION
I made a change in `package.json` but  didn't `bun install` and commit the updated lockfile.

Running `bun install --frozen-lockfile` locally on the contents
of this commit gives the expected error:

```
bun install v1.1.10 (5102a944)
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
```

But CI says: